### PR TITLE
Update AWA-5.0.js

### DIFF
--- a/Website/Scripts/AWA-5.0.js
+++ b/Website/Scripts/AWA-5.0.js
@@ -580,7 +580,7 @@ function testCode() {
   var codeStr = document.getElementById('codeField').value;
 
   //Convert from Awatalk
-  var commandsStrs = codeStr.split(" ");
+  var commandsStrs = codeStr.split((\s+)|((?<=a)(?=a))/gi);
   commandsList = [];
   for (i = 0; i < commandsStrs.length; i++) {
     commandsList.push(parseInt(commandsStrs[i]));

--- a/Website/Scripts/AWA-5.0.js
+++ b/Website/Scripts/AWA-5.0.js
@@ -580,7 +580,7 @@ function testCode() {
   var codeStr = document.getElementById('codeField').value;
 
   //Convert from Awatalk
-  var commandsStrs = codeStr.split((\s+)|((?<=a)(?=a))/gi);
+  var commandsStrs = codeStr.trim().split(/(\s+)|((?<=a)(?=a))/gi);
   commandsList = [];
   for (i = 0; i < commandsStrs.length; i++) {
     commandsList.push(parseInt(commandsStrs[i]));


### PR DESCRIPTION
changing the split method this way would allow for more readability in the editor as you would be able to dedicate each line to a separate command and you could use the lack of a whitespace character to show that a string references to a singular command or number